### PR TITLE
fix: translation strings (DHIS2-10630)

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -8,3 +8,10 @@ minimum_perc = 0
 source_file = i18n/en.pot
 source_lang = en
 type = PO
+
+[app-management-app.i18n_module_en-properties]
+file_filter = public/i18n_legacy/i18n_module_<lang>.properties
+minimum_perc = 0
+source_file = public/i18n_legacy/i18n_module_en.properties
+source_lang = en
+type = PROPERTIES

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,29 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-28T10:39:30.969Z\n"
-"PO-Revision-Date: 2020-08-28T10:39:30.969Z\n"
+"POT-Creation-Date: 2021-03-22T15:30:51.849Z\n"
+"PO-Revision-Date: 2021-03-22T15:30:51.849Z\n"
+
+msgid "Install App"
+msgstr ""
+
+msgid "Uninstall App"
+msgstr ""
+
+msgid "Refresh Apps"
+msgstr ""
+
+msgid "An app was installed"
+msgstr ""
+
+msgid "Load DHIS2 App Hub"
+msgstr ""
+
+msgid "Install App Version from DHIS2 App Hub"
+msgstr ""
+
+msgid "Show Snackbar message"
+msgstr ""
 
 msgid "App installed successfully"
 msgstr ""
@@ -54,6 +75,30 @@ msgid "By"
 msgstr ""
 
 msgid "Install"
+msgstr ""
+
+msgid "Installed Standard Apps"
+msgstr ""
+
+msgid "Installed Dashboard Apps"
+msgstr ""
+
+msgid "Installed Tracker Dashboard Apps"
+msgstr ""
+
+msgid "Installed Resource Apps"
+msgstr ""
+
+msgid "There are no standard apps installed."
+msgstr ""
+
+msgid "There are no dashboard apps installed."
+msgstr ""
+
+msgid "There are no tracker dashboard apps installed."
+msgstr ""
+
+msgid "There are no resource apps installed"
 msgstr ""
 
 msgid "CORE APP"

--- a/public/i18n_legacy/i18n_module_en.properties
+++ b/public/i18n_legacy/i18n_module_en.properties
@@ -1,0 +1,1 @@
+search=Search

--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -12,6 +12,7 @@ import './scss/style.scss'
 
 const AppWrapper = () => {
     const { d2 } = useD2({
+        i18nRoot: './i18n_legacy',
         onInitialized: d2 => {
             installedAppHub.setState(d2.system.installedApps)
         },

--- a/src/actions.js
+++ b/src/actions.js
@@ -10,17 +10,19 @@ const debug = Debug('app-management-app:frontend:client')
 
 const actions = {
     // App management actions
-    installApp: Action.create('Install App'),
-    uninstallApp: Action.create('Uninstall App'),
-    refreshApps: Action.create('Refresh Apps'),
-    appInstalled: Action.create('An app was installed'),
+    installApp: Action.create(i18n.t('Install App')),
+    uninstallApp: Action.create(i18n.t('Uninstall App')),
+    refreshApps: Action.create(i18n.t('Refresh Apps')),
+    appInstalled: Action.create(i18n.t('An app was installed')),
 
     // App store actions
-    loadAppHub: Action.create('Load DHIS2 App Hub'),
-    installAppVersion: Action.create('Install App Version from DHIS2 App Hub'),
+    loadAppHub: Action.create(i18n.t('Load DHIS2 App Hub')),
+    installAppVersion: Action.create(
+        i18n.t('Install App Version from DHIS2 App Hub')
+    ),
 
     // Snackbar
-    showSnackbarMessage: Action.create('Show Snackbar message'),
+    showSnackbarMessage: Action.create(i18n.t('Show Snackbar message')),
 }
 
 /*

--- a/src/components/AppList.component.js
+++ b/src/components/AppList.component.js
@@ -13,24 +13,26 @@ import actions from '../actions'
 import AppTheme from '../theme'
 
 // const appTypeLabels = {
-//     app: 'Standard Apps',
-//     dashboard_widget: 'Dashboard Apps',
-//     tracker_dashboard_widget: 'Tracker Dashboard Apps',
-//     resource: 'Resource Apps',
+//     app: i18n.t('Standard Apps'),
+//     dashboard_widget: i18n.t('Dashboard Apps'),
+//     tracker_dashboard_widget: i18n.t('Tracker Dashboard Apps'),
+//     resource: i18n.t('Resource Apps'),
 // }
 
 const appTypeHeaders = {
-    app: 'Installed Standard Apps',
-    dashboard_widget: 'Installed Dashboard Apps',
-    tracker_dashboard_widget: 'Installed Tracker Dashboard Apps',
-    resource: 'Installed Resource Apps',
+    app: i18n.t('Installed Standard Apps'),
+    dashboard_widget: i18n.t('Installed Dashboard Apps'),
+    tracker_dashboard_widget: i18n.t('Installed Tracker Dashboard Apps'),
+    resource: i18n.t('Installed Resource Apps'),
 }
 
 const appTypeMissing = {
-    app: 'There are no standard apps installed.',
-    dashboard_widget: 'There are no dashboard apps installed.',
-    tracker_dashboard_widget: 'There are no tracker dashboard apps installed.',
-    resource: 'There are no resource apps installed',
+    app: i18n.t('There are no standard apps installed.'),
+    dashboard_widget: i18n.t('There are no dashboard apps installed.'),
+    tracker_dashboard_widget: i18n.t(
+        'There are no tracker dashboard apps installed.'
+    ),
+    resource: i18n.t('There are no resource apps installed'),
 }
 
 const styles = {
@@ -130,9 +132,7 @@ class AppList extends React.Component {
         if (appList.length > 0) {
             return (
                 <div>
-                    <div style={styles.header}>
-                        {i18n.t(appTypeHeaders[label])}
-                    </div>
+                    <div style={styles.header}>{appTypeHeaders[label]}</div>
                     <Card style={styles.card}>
                         <CardText>
                             <List style={styles.container}>
@@ -224,8 +224,8 @@ class AppList extends React.Component {
 
         return (
             <div>
-                <div style={styles.header}>{i18n.t(appTypeHeaders[label])}</div>
-                <div style={styles.noApps}>{i18n.t(appTypeMissing[label])}</div>
+                <div style={styles.header}>{appTypeHeaders[label]}</div>
+                <div style={styles.noApps}>{appTypeMissing[label]}</div>
                 {this.renderUploadButton()}
             </div>
         )


### PR DESCRIPTION
Relates to https://jira.dhis2.org/browse/DHIS2-10630 and https://jira.dhis2.org/browse/DHIS2-10664, I believe

Adds translation strings for page headers and 'no apps installed' messages

**Controversial**: adds legacy i18n to translate '** search **' in the search bar from d2-ui Sidebar (see the second commit). If this one string isn't worth the legacy i18n, especially since Médi is working on the overhaul of this app, I can remove it :)