### PR TITLE
fix: use app hub id instead of name and org for update matching [DHIS2-10859]

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,5 +1,6 @@
 const config = {
     type: 'app',
+    id: '28823170-1203-46d1-81d5-eea67abae41c',
     name: 'app-management',
     title: 'App Management',
     coreApp: true,

--- a/src/.babelrc.js
+++ b/src/.babelrc.js
@@ -1,5 +1,5 @@
 const pkg = require('../package.json')
-const version = pkg.version
+const cfg = require('../d2.config.js')
 
 module.exports = {
     plugins: [
@@ -11,9 +11,16 @@ module.exports = {
                         identifierName: '__VERSION__',
                         replacement: {
                             type: 'stringLiteral',
-                            value: version,
+                            value: pkg.version,
                         },
                     },
+                    {
+                        identifierName: '__APP_HUB_ID__',
+                        replacement: {
+                            type: 'stringLiteral',
+                            value: cfg.id || '',
+                        },
+                    }
                 ],
             },
         ],

--- a/src/components/SelfUpdateNoticeBox.component.js
+++ b/src/components/SelfUpdateNoticeBox.component.js
@@ -1,4 +1,4 @@
-/* global __VERSION__ */
+/* global __VERSION__,__APP_HUB_ID__ */
 
 import i18n from '@dhis2/d2-i18n'
 import { NoticeBox, Button } from '@dhis2/ui'
@@ -8,16 +8,14 @@ import actions from '../actions'
 import { getTargetVersion } from '../utils/versions'
 
 const currentVersion = __VERSION__
-const appManagementAppOrg = 'DHIS2'
-const appManagementAppName = 'App Management'
+const appManagementAppId = __APP_HUB_ID__
 
 export const SelfUpdateNoticeBox = ({ appHub }) => {
     if (!appHub.apps) return null
 
+    // TODO: Fetch app management app from App Hub directly (by id)
     const appManagementApp = appHub.apps.find(
-        app =>
-            app.developer.organisation === appManagementAppOrg &&
-            app.name === appManagementAppName
+        app => app.id === appManagementAppId
     )
 
     const targetVersion = getTargetVersion(


### PR DESCRIPTION
This updates #127 to also use app id for comparison, achieving parity with #215 and #217