### PR TITLE
fix: use overriden core app versions

### DIFF
--- a/src/components/AppsList/AppsList.js
+++ b/src/components/AppsList/AppsList.js
@@ -16,7 +16,7 @@ const AppCards = ({ apps }) => {
             return
         }
         history.push(
-            app.version ? `/installed-app/${app.key}` : `/app/${app.appHub.id}`
+            app.appHub ? `/app/${app.appHub.id}` : `/installed-app/${app.key}`
         )
     }
 

--- a/src/pages/CoreApps/CoreApps.js
+++ b/src/pages/CoreApps/CoreApps.js
@@ -81,6 +81,7 @@ export const CoreApps = () => {
         if (!(app.short_name in appsByShortName)) {
             appsByShortName[app.short_name] = app
         }
+        appsByShortName[app.short_name].version = app.version
     })
     const apps = Object.values(appsByShortName)
     const appsWithUpdates = apps.filter(


### PR DESCRIPTION
If a core app has been overriden, we should use the installed version instead of the bundled version when checking if updates for that core app are available.