### PR TITLE
fix: support core and custom app management when app hub is not available

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-08T13:42:45.950Z\n"
-"PO-Revision-Date: 2021-09-08T13:42:45.950Z\n"
+"POT-Creation-Date: 2022-11-16T12:52:56.478Z\n"
+"PO-Revision-Date: 2022-11-16T12:52:56.478Z\n"
 
 msgid "Version {{version}} installed"
 msgstr "Version {{version}} installed"
@@ -94,6 +94,12 @@ msgstr "Development"
 
 msgid "Canary"
 msgstr "Canary"
+
+msgid "Failed to check App Hub for available updates"
+msgstr "Failed to check App Hub for available updates"
+
+msgid "Your DHIS2 server might be offline."
+msgstr "Your DHIS2 server might be offline."
 
 msgid "No apps found"
 msgstr "No apps found"

--- a/src/components/AppDetails/AppDetails.module.css
+++ b/src/components/AppDetails/AppDetails.module.css
@@ -1,5 +1,6 @@
 .appCard {
     max-width: 960px;
+    height: auto !important;
 }
 
 .header, .section {

--- a/src/components/AppHubErrorNoticeBox/AppHubErrorNoticeBox.js
+++ b/src/components/AppHubErrorNoticeBox/AppHubErrorNoticeBox.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { NoticeBox } from '@dhis2/ui'
+import styles from './AppHubErrorNoticeBox.module.css'
+import i18n from '../../locales/index.js'
+
+export const AppHubErrorNoticeBox = () => 
+    <NoticeBox
+        error
+        title={i18n.t(
+            'Failed to check App Hub for available updates'
+        )}
+        className={styles.NoticeBox}
+    >
+        {i18n.t('Your DHIS2 server might be offline.')}
+    </NoticeBox>

--- a/src/components/AppHubErrorNoticeBox/AppHubErrorNoticeBox.module.css
+++ b/src/components/AppHubErrorNoticeBox/AppHubErrorNoticeBox.module.css
@@ -1,0 +1,3 @@
+.NoticeBox {
+    margin-bottom: var(--spacers-dp16);
+}

--- a/src/pages/InstalledApp/InstalledApp.js
+++ b/src/pages/InstalledApp/InstalledApp.js
@@ -5,6 +5,7 @@ import { NoticeBox, CenteredContent, CircularLoader } from '@dhis2/ui'
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 import { AppDetails } from '../../components/AppDetails/AppDetails.js'
+import { AppHubErrorNoticeBox } from '../../components/AppHubErrorNoticeBox/AppHubErrorNoticeBox.js'
 
 const appsQuery = {
     modules: {
@@ -28,10 +29,10 @@ export const InstalledApp = ({ match }) => {
     const appsResponse = useDataQuery(appsQuery)
     const appHubResponse = useDataQuery(appHubQuery, { lazy: true })
 
-    if (appsResponse.error || appHubResponse.error) {
+    if (appsResponse.error) {
         return (
             <NoticeBox error title={i18n.t('Error loading app')}>
-                {(appsResponse.error || appHubResponse.error).message}
+                {appsResponse.error.message}
             </NoticeBox>
         )
     }
@@ -72,14 +73,15 @@ export const InstalledApp = ({ match }) => {
         )
     }
 
-    return (
+    return (<>
+        {appHubResponse.error && <AppHubErrorNoticeBox />}
         <AppDetails
             installedApp={app}
             appHubApp={appHubResponse.data?.app}
             onVersionInstall={appsResponse.refetch}
             onUninstall={() => history.push('/custom-apps')}
         />
-    )
+    </>)
 }
 
 InstalledApp.propTypes = {


### PR DESCRIPTION
This separates DHIS2 API errors from App Hub errors to support managing locally-installed apps even if the server is offline or the App Hub is down.

The code in these places could be a fair bit cleaner, but I went for minimal changes here.