### PR TITLE
fix: use unambiguous short date [DHIS2-14183]

### DIFF
--- a/src/components/AppDetails/Versions.js
+++ b/src/components/AppDetails/Versions.js
@@ -107,7 +107,9 @@ const VersionsTable = ({ installedVersion, versions, onVersionInstall }) => (
                     <TableCell>
                         {channelToDisplayName[version.channel]}
                     </TableCell>
-                    <TableCell>{moment(version.created).format('L')}</TableCell>
+                    <TableCell>
+                        {moment(version.created).format('ll')}
+                    </TableCell>
                     <TableCell>
                         <Button
                             small


### PR DESCRIPTION
This makes the date non-ambiguous (particularly relevant when you have language set to English as the default format for 'en' locale is MM/DD/YYYY which may not be the format that our users expect)

This is an analogue to the ticket to update the app hub (https://dhis2.atlassian.net/browse/HUB-149)

It might be good if we tried to use `keyDateFormat` system setting on the front end, so that users could choose their date format to provide some consistency generally (out of scope of this ticket 😜) ?

**Before (with English as user language)**
<img width="928" alt="image" src="https://user-images.githubusercontent.com/18490902/203526230-9ce7a202-ff0a-49a9-832d-75369bea2e22.png">

**After (with English as user language)**
<img width="938" alt="image" src="https://user-images.githubusercontent.com/18490902/203526268-3863ecce-ea3f-4710-b062-9dd243df6811.png">
