### PR TITLE
fix: parse error message properly for manual installs

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -13,15 +13,22 @@ class Api {
             credentials: 'include',
             redirect: 'manual',
         }).then(async (res) => {
-            if (res.type === 'opaqueredirect') {
-                throw {
-                    message: i18n.t(
-                        'Your session has expired. Please refresh the page and login before trying again.'
-                    ),
+            let errorBody
+            try {
+                if (res.type === 'opaqueredirect') {
+                    errorBody = {
+                        message: i18n.t(
+                            'Your session has expired. Please refresh the page and login before trying again.'
+                        ),
+                    }
+                } else if (res.status < 200 || res.status >= 300) {
+                    errorBody = await res.json()
                 }
+            } catch (err) {
+                throw new Error(i18n.t('An unexpected error occurred'))
             }
-            if (res.status < 200 || res.status >= 300) {
-                const errorBody = await res.json()
+
+            if (errorBody) {
                 throw errorBody
             }
             return res


### PR DESCRIPTION
fixes [DHIS2-13883](https://dhis2.atlassian.net/browse/DHIS2-13883) and [DHIS2-15304](https://dhis2.atlassian.net/browse/DHIS2-15304).

1. With fetch, API errors are not thrown as errors, and we need to do `res.json()` to get their content. This fixes error handling there so that the error details are surfaced to the consumers.

![image](https://github.com/dhis2/app-management-app/assets/1014725/e36404d6-a3c3-41b5-b5e9-2af3c69ac3df)


[DHIS2-13883]: https://dhis2.atlassian.net/browse/DHIS2-13883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

2. It was a bit trickier with unauthenticated requests, fetch - by default - follows the redirect implicitly so had to change its mode to `manual`  then the response we get back doesn't have a 302 but a property we can check - more info [here](https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect)

![image](https://github.com/dhis2/app-management-app/assets/1014725/a29821ae-5d4b-4183-9aaf-273c9ee32e69)


[DHIS2-15304]: https://dhis2.atlassian.net/browse/DHIS2-15304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ