### PR TITLE
feat: add open button to app details page [DHIS2-13885]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-09-26T12:27:51.211Z\n"
-"PO-Revision-Date: 2024-09-26T12:27:51.211Z\n"
+"POT-Creation-Date: 2024-10-29T11:22:33.823Z\n"
+"PO-Revision-Date: 2024-10-29T11:22:33.823Z\n"
 
 msgid ""
 "Your session has expired. Please refresh the page and login before trying "
@@ -32,6 +32,9 @@ msgstr "First published {{relativeTime}}"
 
 msgid "by {{- developer}}"
 msgstr "by {{- developer}}"
+
+msgid "Open"
+msgstr "Open"
 
 msgid "About this app"
 msgstr "About this app"

--- a/src/components/AppDetails/AppDetails.js
+++ b/src/components/AppDetails/AppDetails.js
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Card, Divider } from '@dhis2/ui'
+import { Button, Card, Divider } from '@dhis2/ui'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
@@ -120,6 +120,15 @@ export const AppDetails = ({
                                 context: 'developer of application',
                             })}
                         </span>
+                    )}
+                </div>
+                <div>
+                    {installedApp?.launchUrl && (
+                        <a href={installedApp.launchUrl} target="_blank">
+                            <Button className={styles.openLink}>
+                                {i18n.t('Open')}
+                            </Button>
+                        </a>
                     )}
                 </div>
             </header>

--- a/src/components/AppDetails/AppDetails.js
+++ b/src/components/AppDetails/AppDetails.js
@@ -124,7 +124,11 @@ export const AppDetails = ({
                 </div>
                 <div>
                     {installedApp?.launchUrl && (
-                        <a href={installedApp.launchUrl} target="_blank">
+                        <a
+                            href={installedApp.launchUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
                             <Button className={styles.openLink}>
                                 {i18n.t('Open')}
                             </Button>

--- a/src/components/AppDetails/AppDetails.module.css
+++ b/src/components/AppDetails/AppDetails.module.css
@@ -9,7 +9,7 @@
 
 .header {
     display: grid;
-    grid-template-columns: 72px auto;
+    grid-template-columns: min-content auto min-content;
     grid-gap: var(--spacers-dp16);
     align-items: center;
     line-height: 24px;
@@ -44,7 +44,7 @@
 .mainSection {
     display: grid;
     grid-gap: var(--spacers-dp24);
-    grid-template-columns: 60% auto;
+    grid-template-columns: auto max-content;
 }
 
 .manageInstalledVersion {
@@ -126,4 +126,9 @@
 
 .downloadLink {
     text-decoration: none;
+}
+
+.openLink::after {
+    content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+    margin: 0px 3px 0px 5px;
 }

--- a/src/components/AppDetails/ManageInstalledVersion.js
+++ b/src/components/AppDetails/ManageInstalledVersion.js
@@ -96,11 +96,11 @@ export const ManageInstalledVersion = ({
     return (
         <div className={styles.manageInstalledVersion}>
             {!hasCompatibleVersions && (
-                <>
+                <div>
                     <em>
                         {i18n.t('There are no compatible versions available.')}
                     </em>
-                </>
+                </div>
             )}
             {hasCompatibleVersions && canInstall && (
                 <>
@@ -122,7 +122,7 @@ export const ManageInstalledVersion = ({
                 </>
             )}
             {canUninstall && (
-                <Button secondary onClick={handleUninstall}>
+                <Button secondary destructive onClick={handleUninstall}>
                     {i18n.t('Uninstall v{{appVersion}}', {
                         appVersion: installedApp.version,
                     })}


### PR DESCRIPTION
Fixes [DHIS2-13885](https://dhis2.atlassian.net/browse/DHIS2-13885)

This adds a simple "Open" button to the top right of installed app pages in the App Management App, allowing the user to easily access the installed app (opening in a new tab)

Apps which are not yet installed or which don't have a launchUrl (for example plugins) don't display the button.

The design of this could be improved, but I think this is an important enough UX improvement to warrant deferring the perfect UI.

This also updates slightly the CSS rules to ensure the right column with app metadata doesn't shrink even on smaller screens. 

Finally, the "Uninstall" button now has a secondary destructive style.

![Screenshot 2024-10-29 at 12 23 56](https://github.com/user-attachments/assets/829f61bc-d911-4c18-adc8-4b924e7c208c)
![Screenshot 2024-10-29 at 12 23 40](https://github.com/user-attachments/assets/ebf57983-b0dc-4c43-8200-fe9fa115ae60)


[DHIS2-13885]: https://dhis2.atlassian.net/browse/DHIS2-13885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ