### PR TITLE
chore: integrate iframe from apphub to show changelog

### DIFF
--- a/src/components/AppDetails/AppDetails.js
+++ b/src/components/AppDetails/AppDetails.js
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import { Button, Card, Divider } from '@dhis2/ui'
 import moment from 'moment'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { getAppIconSrc } from '../../get-app-icon-src.js'
 import { getLatestVersion } from '../../get-latest-version.js'
 import { AppIcon } from '../AppIcon/AppIcon.js'
@@ -10,6 +10,9 @@ import styles from './AppDetails.module.css'
 import { Description } from './Description.js'
 import { ManageInstalledVersion } from './ManageInstalledVersion.js'
 import { Versions } from './Versions.js'
+import { useApi } from '../../api.js'
+import { useAlert, useConfig } from '@dhis2/app-runtime'
+import semver from 'semver'
 
 const Metadata = ({ installedVersion, versions }) => {
     const relativeTime = (datetime) => moment(datetime).fromNow()
@@ -105,39 +108,104 @@ export const AppDetails = ({
         .map((i) => i.imageUrl)
     const versions = appHubApp?.versions.sort((a, b) => b.created - a.created)
 
+    const { installVersion, uninstallApp } = useApi()
+
+    const installSuccessAlert = useAlert(i18n.t('App installed successfully'), {
+        success: true,
+    })
+
+    const { serverVersion } = useConfig()
+
+    const dhisVersion = `${serverVersion.major}.${serverVersion.minor}`
+
+    console.log('???', serverVersion, dhisVersion)
+
+    const onInstall = async (version) => {
+        await installVersion(version)
+        installSuccessAlert.show()
+        onVersionInstall()
+    }
+
+    useEffect(() => {
+        window.onmessage = async (e) => {
+            if (e.data?.action === 'install') {
+                console.log(e.data)
+                // alert(JSON.stringify(e.data))
+                await onInstall(e.data?.version?.id)
+            }
+            // if (e.data == 'hello') {
+            //     alert('It works!')
+            // }
+        }
+    })
+
+    // const dhisVersion = '2.41'
+
     return (
         <Card className={styles.appCard}>
             <header className={styles.header}>
-                <div>
-                    <AppIcon src={logo} />
+                <div style={{ display: 'flex' }}>
+                    <div>
+                        <AppIcon src={logo} />
+                    </div>
+                    <div>
+                        <h1 className={styles.headerName}>{appName}</h1>
+                        {appDeveloper && (
+                            <span className={styles.headerDeveloper}>
+                                {i18n.t('by {{- developer}}', {
+                                    developer: appDeveloper,
+                                    context: 'developer of application',
+                                })}
+                            </span>
+                        )}
+                    </div>
                 </div>
-                <div>
-                    <h1 className={styles.headerName}>{appName}</h1>
-                    {appDeveloper && (
-                        <span className={styles.headerDeveloper}>
-                            {i18n.t('by {{- developer}}', {
-                                developer: appDeveloper,
-                                context: 'developer of application',
-                            })}
-                        </span>
-                    )}
-                </div>
-                <div>
-                    {installedApp?.launchUrl && (
-                        <a
-                            href={installedApp.launchUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            <Button className={styles.openLink}>
-                                {i18n.t('Open')}
-                            </Button>
-                        </a>
-                    )}
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                    }}
+                >
+                    <div>
+                        <ManageInstalledVersion
+                            installedApp={installedApp}
+                            versions={appHubApp?.versions}
+                            onVersionInstall={onVersionInstall}
+                            onUninstall={onUninstall}
+                        />
+                        {/* {installedApp && appHubApp && (
+                            <div>
+                                <h2 className={styles.sectionHeader}>
+                                    {i18n.t('Additional information')}
+                                </h2>
+                                <Metadata
+                                    installedVersion={installedApp.version}
+                                    versions={versions}
+                                />
+                            </div>
+                        )} */}
+                    </div>
+                    <div style={{ width: '100%' }}>
+                        {installedApp?.launchUrl && (
+                            <a
+                                href={installedApp.launchUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                <Button
+                                    style={{ width: '100%' }}
+                                    className={styles.openLink}
+                                >
+                                    {i18n.t('Open')}
+                                </Button>
+                            </a>
+                        )}
+                    </div>
                 </div>
             </header>
-            <Divider />
-            <section className={[styles.section, styles.mainSection].join(' ')}>
+            {/* <Divider /> */}
+            {/* <section className={[styles.section, styles.mainSection].join(' ')}>
                 <div>
                     <h2 className={styles.sectionHeader}>
                         {i18n.t('About this app')}
@@ -152,26 +220,13 @@ export const AppDetails = ({
                         </em>
                     )}
                 </div>
-                <div>
-                    <ManageInstalledVersion
-                        installedApp={installedApp}
-                        versions={appHubApp?.versions}
-                        onVersionInstall={onVersionInstall}
-                        onUninstall={onUninstall}
-                    />
-                    {installedApp && appHubApp && (
-                        <div>
-                            <h2 className={styles.sectionHeader}>
-                                {i18n.t('Additional information')}
-                            </h2>
-                            <Metadata
-                                installedVersion={installedApp.version}
-                                versions={versions}
-                            />
-                        </div>
-                    )}
-                </div>
-            </section>
+            </section> */}
+            <iframe
+                width="100%"
+                height="1000px"
+                style={{ border: 0 }}
+                src={`http://localhost:8080/static/app/${appHubApp.id}?compatibleWith=${dhisVersion}`}
+            />
             {screenshots?.length > 0 && (
                 <>
                     <Divider />

--- a/src/components/AppDetails/AppDetails.module.css
+++ b/src/components/AppDetails/AppDetails.module.css
@@ -8,10 +8,10 @@
 }
 
 .header {
-    display: grid;
-    grid-template-columns: min-content auto min-content;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
     grid-gap: var(--spacers-dp16);
-    align-items: center;
     line-height: 24px;
 }
 


### PR DESCRIPTION
this is a POC to see if we could integrate AppHub as an iframe

- any comments about the implementations and the communication between the iframes
- any security concerns?
- are there scenarios where this might not work - I am thinking maybe, a CSP policy on DHIS implementations, could be blocking iframes from other domains
  - or some installations that would be served on LAN, and so being   
  - I could route to AppHub from DHIS2 core, but then that introduces issues that the core also needs to be the latest for this to work...

The benefit is that we will stop all the duplication between app-management and app-hub..

related to it is this AppHub PR mainly to expose a page that shows only the tabs part of AppView without AppHub header and sidebars: https://github.com/dhis2/app-hub/pull/749/files

Here is how it looks and works (we can improve the UX if this route is OK - I got rid of the header info bar that was on the left of the app title, as it didn't look right anymore)
 
[appmanagement-app-iframe.webm](https://github.com/user-attachments/assets/c7d64d42-ad8f-402e-8b91-395fe2ca3489)




