### PR TITLE
fix(DHIS2-19515): update logic for displaying icons for bundled apps

### DIFF
--- a/src/components/AppCard/AppCard.jsx
+++ b/src/components/AppCard/AppCard.jsx
@@ -15,7 +15,11 @@ export const AppCard = ({
     appVersion,
     onClick,
 }) => (
-    <button className={styles.appCard} onClick={onClick}>
+    <button
+        data-test={`appcard-${appName}`}
+        className={styles.appCard}
+        onClick={onClick}
+    >
         <AppIcon src={iconSrc} />
         <div>
             <h2 className={styles.appCardName}>{appName}</h2>

--- a/src/get-app-icon-src.js
+++ b/src/get-app-icon-src.js
@@ -3,10 +3,7 @@ export const getAppIconSrc = (app) => {
         (iconSize) => iconSize in app.icons
     )
     if (iconSize) {
-        if (/^https?:\/\//.test(app.icons[iconSize])) {
-            return app.icons[iconSize]
-        }
-        return `${app.baseUrl}/${app.icons[iconSize]}`
+        return app.icons[iconSize]
     }
     return null
 }

--- a/src/pages/CoreApps/CoreApps.jsx
+++ b/src/pages/CoreApps/CoreApps.jsx
@@ -78,15 +78,17 @@ export const CoreApps = () => {
         }
         const { shortName } = coreApp
         const module = data.modules.modules.find(
-            (m) => m.name === `dhis-web-${shortName}`
+            (m) => m.name === shortName || m.name === `dhis-web-${shortName}`
         )
         const name = app.name
         const iconUrl = module?.icon
-        const icons = iconUrl ? { 48: iconUrl } : {}
+        const iconBaseUrl = iconUrl?.startsWith('/apps')
+            ? `${baseUrl}/api`
+            : `${baseUrl}/dhis-web-${shortName}/`
+        const icons = iconUrl ? { 48: iconBaseUrl + iconUrl } : {}
         appsByShortName[shortName] = {
             short_name: shortName,
             appHub: app,
-            baseUrl: `${baseUrl}/dhis-web-${shortName}`,
             name,
             icons,
         }

--- a/src/pages/CoreApps/CoreApps.spec.jsx
+++ b/src/pages/CoreApps/CoreApps.spec.jsx
@@ -1,0 +1,104 @@
+import { CustomDataProvider, Provider } from '@dhis2/app-runtime'
+import { render } from '@testing-library/react'
+import React from 'react'
+import { QueryParamProvider } from 'use-query-params'
+import { CoreApps } from './CoreApps.jsx'
+
+const renderWithProvider = (component, dataForCustomProvider = {}) => {
+    return render(component, {
+        wrapper: ({ children }) => {
+            return (
+                <QueryParamProvider>
+                    <Provider
+                        config={{
+                            baseUrl: 'http://localhost:8080',
+                            systemInfo: {
+                                version: 2.4,
+                            },
+                        }}
+                    >
+                        <CustomDataProvider
+                            data={dataForCustomProvider}
+                            options={{ failOnMiss: true }}
+                        >
+                            {children}
+                        </CustomDataProvider>
+                    </Provider>
+                </QueryParamProvider>
+            )
+        },
+    })
+}
+
+describe('Core apps', () => {
+    const appHubResponse = [
+        {
+            name: 'Dashboard',
+            description:
+                'Present a high level overview of your data in a dashboard...',
+        },
+    ]
+    it('should display icons for v41 and below', async () => {
+        const { getAllByTestId, findAllByText } = renderWithProvider(
+            <CoreApps />,
+            {
+                apps: [],
+                'action::menu/getModules': () => {
+                    return {
+                        modules: [
+                            {
+                                name: 'dhis-web-dashboard',
+                                namespace: '/dhis-web-dashboard',
+                                defaultAction:
+                                    '../dhis-web-dashboard/index.action',
+                                displayName: 'Dashboard',
+                                icon: '../icons/dhis-web-dashboard.png',
+                                description: '',
+                            },
+                        ],
+                    }
+                },
+                'appHub/v2/apps': appHubResponse,
+            }
+        )
+
+        await findAllByText('Dashboard')
+
+        expect(
+            getAllByTestId('appcard-Dashboard')[0].querySelector('img').src
+        ).toBe('http://localhost:8080/icons/dhis-web-dashboard.png')
+    })
+
+    it('should display icons for v42+', async () => {
+        const { getAllByTestId, findAllByText } = renderWithProvider(
+            <CoreApps />,
+            {
+                apps: [],
+                'action::menu/getModules': () => {
+                    return {
+                        modules: [
+                            {
+                                name: 'dashboard',
+                                namespace: '/api/apps/dashboard',
+                                defaultAction:
+                                    'http://localhost:8080/dhis-web-dashboard/index.html',
+                                displayName: 'Dashboard',
+                                icon: '/apps/dashboard/dhis2-app-icon.png',
+                                description: 'DHIS2 Dashboard app',
+                                version: '101.2.1',
+                                shortcuts: [],
+                            },
+                        ],
+                    }
+                },
+                'appHub/v2/apps': appHubResponse,
+            }
+        )
+
+        await findAllByText('Dashboard')
+
+        expect(
+            getAllByTestId('appcard-Dashboard')[0].querySelector('img').src
+        ).toBe('http://localhost:8080/api/apps/dashboard/dhis2-app-icon.png')
+    })
+})


### PR DESCRIPTION
updates the logic for displaying icons so that it works on both the response for v42+ and the older responses before 41.

fixes https://dhis2.atlassian.net/browse/DHIS2-19515

