### PR TITLE
fix(DHIS2-19677): open markdown links in new page

### DIFF
--- a/src/components/AppDetails/LatestUpdates.jsx
+++ b/src/components/AppDetails/LatestUpdates.jsx
@@ -33,7 +33,21 @@ export const LatestUpdates = ({ changelog, installedVersion, versions }) => {
                                     {version.version}
                                 </h3>
                                 <div className={styles.changeSummary}>
-                                    <ReactMarkdown>
+                                    <ReactMarkdown
+                                        components={{
+                                            a(props) {
+                                                // eslint-disable-next-line react/prop-types, no-unused-vars
+                                                const { node, ...rest } = props
+                                                return (
+                                                    <a
+                                                        {...rest}
+                                                        rel="noopener noreferrer"
+                                                        target="_blank"
+                                                    />
+                                                )
+                                            },
+                                        }}
+                                    >
                                         {changelog[version.version]}
                                     </ReactMarkdown>
                                 </div>

--- a/src/components/AppDetails/Versions.jsx
+++ b/src/components/AppDetails/Versions.jsx
@@ -148,7 +148,23 @@ const VersionsTable = ({
 
                         <div className={versionsStyles.changeSummary}>
                             {changes && (
-                                <ReactMarkdown>{changes}</ReactMarkdown>
+                                <ReactMarkdown
+                                    components={{
+                                        a(props) {
+                                            // eslint-disable-next-line react/prop-types, no-unused-vars
+                                            const { node, ...rest } = props
+                                            return (
+                                                <a
+                                                    {...rest}
+                                                    rel="noopener noreferrer"
+                                                    target="_blank"
+                                                />
+                                            )
+                                        },
+                                    }}
+                                >
+                                    {changes}
+                                </ReactMarkdown>
                             )}
                         </div>
                         <Divider className={versionsStyles.versionDivider} />


### PR DESCRIPTION
This fixes a bug where the links to the commits in the rendered markdown of a release note, seems to be trapped by global shell and don't open (not inline, not in a new page). 

The fix here instructs react-markdown to update any `a` tag to add `target=_blank` - but maybe we should check why this specific case is not handled by Global Shell as expected.