### PR TITLE
fix(DHIS2-19851): ensure that stable versions are shown as latest version

### DIFF
--- a/src/components/AppDetails/AppDetails.jsx
+++ b/src/components/AppDetails/AppDetails.jsx
@@ -27,7 +27,8 @@ const Metadata = ({ installedVersion, versions }) => {
     const relativeTime = (datetime) => moment(datetime).fromNow()
     const latestVersion = getLatestVersion(versions)?.version
     const firstPublishedVersion = versions[versions.length - 1]
-    const lastPublishedVersion = versions[0]
+    const stableVersions = versions.filter((v) => v.channel === 'stable')
+    const lastPublishedVersion = stableVersions[0]
 
     return (
         <ul className={styles.metadataList}>
@@ -117,6 +118,9 @@ export const AppDetails = ({
         .filter((i) => !i.logo)
         .map((i) => i.imageUrl)
     const versions = appHubApp?.versions.sort((a, b) => b.created - a.created)
+    const stableVersions = appHubApp?.versions.filter(
+        (v) => v.channel === 'stable'
+    )
 
     const history = useHistory()
 
@@ -216,7 +220,7 @@ export const AppDetails = ({
                             {hasChangelog && (
                                 <LatestUpdates
                                     installedVersion={installedApp?.version}
-                                    versions={versions}
+                                    versions={stableVersions}
                                     changelog={changelog}
                                 />
                             )}

--- a/src/components/AppDetails/AppDetails.jsx
+++ b/src/components/AppDetails/AppDetails.jsx
@@ -118,9 +118,6 @@ export const AppDetails = ({
         .filter((i) => !i.logo)
         .map((i) => i.imageUrl)
     const versions = appHubApp?.versions.sort((a, b) => b.created - a.created)
-    const stableVersions = appHubApp?.versions.filter(
-        (v) => v.channel === 'stable'
-    )
 
     const history = useHistory()
 
@@ -220,7 +217,7 @@ export const AppDetails = ({
                             {hasChangelog && (
                                 <LatestUpdates
                                     installedVersion={installedApp?.version}
-                                    versions={stableVersions}
+                                    versions={versions}
                                     changelog={changelog}
                                 />
                             )}

--- a/src/components/AppDetails/ManageInstalledVersion.jsx
+++ b/src/components/AppDetails/ManageInstalledVersion.jsx
@@ -20,7 +20,9 @@ export const ManageInstalledVersion = ({
     // apps their `version` field has a value
     const isBundled =
         installedApp && installedApp.bundled && !installedApp.version
-    const latestVersion = getLatestVersion(versions)
+    const stableVersions = versions.filter((v) => v.channel === 'stable')
+    const latestVersion = getLatestVersion(stableVersions)
+
     const canInstall =
         latestVersion && latestVersion.version !== installedApp?.version
 

--- a/src/pages/AppHub/AppHub.jsx
+++ b/src/pages/AppHub/AppHub.jsx
@@ -38,21 +38,26 @@ const AppCards = ({ apps }) => {
 
     return (
         <AppCards_>
-            {apps.map((app) => (
-                <AppCard
-                    key={app.id}
-                    hasPlugin={app.hasPlugin}
-                    pluginType={app.pluginType}
-                    appType={app.appType}
-                    iconSrc={getIconSrc(app)}
-                    appName={app.name}
-                    appDeveloper={
-                        app.developer.organisation || app.developer.name
-                    }
-                    appVersion={getLatestVersion(app.versions).version}
-                    onClick={() => history.push(`/app/${app.id}`)}
-                />
-            ))}
+            {apps.map((app) => {
+                const stableVersions = app?.versions.filter(
+                    (v) => v.channel === 'stable'
+                )
+                return (
+                    <AppCard
+                        key={app.id}
+                        hasPlugin={app.hasPlugin}
+                        pluginType={app.pluginType}
+                        appType={app.appType}
+                        iconSrc={getIconSrc(app)}
+                        appName={app.name}
+                        appDeveloper={
+                            app.developer.organisation || app.developer.name
+                        }
+                        appVersion={getLatestVersion(stableVersions).version}
+                        onClick={() => history.push(`/app/${app.id}`)}
+                    />
+                )
+            })}
         </AppCards_>
     )
 }


### PR DESCRIPTION
This ensures that the stable version of an app - not development, or canary - is shown as the latest version to install.

| Before | After |
| --- | --- |
| <img width="2133" height="821" alt="image" src="https://github.com/user-attachments/assets/672e5b66-1e8c-428c-8936-9dff47601295" /> |  <img width="2133" height="821" alt="image" src="https://github.com/user-attachments/assets/e11a1630-0d98-4df2-adf5-7c1cb0d054b4" /> |

| Before | After |
| --- | --- |
| <img width="2061" height="1425" alt="image" src="https://github.com/user-attachments/assets/fb1a76d3-78f8-489b-af6d-a9b3dd35ccb2" /> | <img width="2061" height="1425" alt="image" src="https://github.com/user-attachments/assets/afedd00f-4bc3-482d-a355-083172c08833" /> |

fixes https://dhis2.atlassian.net/browse/HUB-169
